### PR TITLE
Updates to fix the CI build for polly.

### DIFF
--- a/.build/dependencies.sh
+++ b/.build/dependencies.sh
@@ -19,6 +19,19 @@ go get -v golang.org/x/tools/cmd/cover
 if [[ $(uname -s) != Linux ]]; then exit 0; fi
 
 ########################################################################
+##                             go-bindata                             ##
+########################################################################
+
+GBD_GIT=https://github.com/akutz/go-bindata.git
+GBD_DIR=$GOPATH/src/github.com/jteeuwen/go-bindata
+mkdir -p $GBD_DIR
+cd $GBD_DIR
+git clone $GBD_GIT .
+git checkout feature/md5checksum
+go install ./...
+cd $cwd
+
+########################################################################
 ##                             alien                                  ##
 ########################################################################
 

--- a/Makefile
+++ b/Makefile
@@ -226,6 +226,10 @@ build: _pre-make _build _post-make
 _build: _deps _fmt build_
 build_:
 	@echo "target: build"
+	@printf "  ...building libstorage executor $(V_OS_ARCH)..."; \
+	  cd $(BASEDIR)/vendor/github.com/emccode/libstorage; \
+		mkdir -p api/server/executors/bin; \
+		go-bindata -md5checksum -pkg executors -prefix api/server/executors/bin -o api/server/executors/executors_generated.go api/server/executors/bin/...
 	@printf "  ...building polly $(V_OS_ARCH)..."; \
 		cd $(BASEDIR); \
 		FILE=$(BINDIR)/$(V_OS_ARCH)/polly; \
@@ -309,7 +313,7 @@ _install: _deps _fmt
 			FILE=$(GOPATH)/bin/polly; \
 			BYTES=$$($(STAT_FILE_SIZE)); \
 			SIZE=$$(($$BYTES / 1024 / 1024)); \
-			printf "\nThe REX-Ray binary is $${SIZE}MB and located at:\n\n"; \
+			printf "\nThe Polly binary is $${SIZE}MB and located at:\n\n"; \
 			printf "  $$FILE\n\n"; \
 		fi
 
@@ -386,7 +390,7 @@ rpm:
 			cp -f $$FILE $(DEPLOY)/latest/polly-latest-$(V_ARCH).rpm; \
 			BYTES=$$($(STAT_FILE_SIZE)); \
 			SIZE=$$(($$BYTES / 1024 / 1024)); \
-			printf "\nThe REX-Ray RPM is $${SIZE}MB and located at:\n\n"; \
+			printf "\nThe Polly RPM is $${SIZE}MB and located at:\n\n"; \
 			printf "  $$FILE\n\n"; \
 		fi
 
@@ -416,7 +420,7 @@ deb:
 			cp -f $$FILE $(DEPLOY)/latest/polly-latest-$(V_ARCH).deb; \
 			BYTES=$$($(STAT_FILE_SIZE)); \
 			SIZE=$$(($$BYTES / 1024 / 1024)); \
-			printf "\nThe REX-Ray DEB is $${SIZE}MB and located at:\n\n"; \
+			printf "\nThe Polly DEB is $${SIZE}MB and located at:\n\n"; \
 			printf "  $$FILE\n\n"; \
 		fi
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# polly - Polymorphic Volume Scheduling
+# polly - Polymorphic Volume Scheduling ![Build Status](https://travis-ci.org/emccode/polly.svg?branch=master) ![Go Report Card](http://goreportcard.com/badge/emccode/polly) ![codecov.io](https://codecov.io/github/emccode/polly/coverage.svg?branch=master)
 
 ![polly](docs/images/Polly the Parrot_Containers.png)
 

--- a/glide.yaml
+++ b/glide.yaml
@@ -15,7 +15,7 @@ import:
   - package: github.com/emccode/libstorage
     ref:     2a4d9533c7e4183c9ea98c7bfc7ee753a7235798
     vcs:     git
-    repo:    /Users/clintonkitson/go/src/github.com/emccode/libstorage
+    repo:    https://github.com/clintonskitson/libstorage
   - package: github.com/docker/libkv
     vcs:     git
   - package: github.com/boltdb/bolt

--- a/polly.go
+++ b/polly.go
@@ -1,0 +1,20 @@
+package polly
+
+import (
+	"github.com/akutz/gofig"
+
+	core "github.com/emccode/polly/core"
+	ctypes "github.com/emccode/polly/core/types"
+)
+
+// NewWithConfigFile creates a new Polly instance and configures it with a
+// custom configuration file.
+func NewWithConfigFile(path string) (*ctypes.Polly, error) {
+	return core.NewWithConfigFile(path)
+}
+
+// NewWithConfig creates a new Polly instance and configures it with a
+// custom configuration stream.
+func NewWithConfig(config gofig.Config) *ctypes.Polly {
+	return core.NewWithConfig(config)
+}


### PR DESCRIPTION
This should fix the following:
* libstorage executor is now dynamically built in the vendor dir
* polly.go exists at root so that the repo can be properly pulled using "go get". this file was mimic based on the rexray.go at the root of the rexray repo
* first stab at adding some badges (build, ci, code coverage) to polly. will update with more later.