### PR TITLE
More CI Updates

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,3 @@
+go:
+  enabled: true
+fail_on_violations: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,9 @@ deploy:
       all_branches: true
       condition: $TRAVIS_TAG =~ ^v?[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]$ && ($TRAVIS_REPO_SLUG = 'emccode/polly' || $IGNORE_REPO_SLUG_CONDITION = true)
 
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
+
 cache:
   apt: true
   directories:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# polly - Polymorphic Volume Scheduling ![Build Status](https://travis-ci.org/emccode/polly.svg?branch=master) ![Go Report Card](http://goreportcard.com/badge/emccode/polly) ![codecov.io](https://codecov.io/github/emccode/polly/coverage.svg?branch=master)
+# polly - Polymorphic Volume Scheduling
+[![Build Status](https://travis-ci.org/emccode/polly.svg?branch=master)](https://travis-ci.org/emccode/polly) [![Go Report Card](http://goreportcard.com/badge/emccode/polly)](http://goreportcard.com/report/emccode/polly) ![codecov.io](https://codecov.io/github/emccode/polly/coverage.svg?branch=master) [![Coverage Status](https://coveralls.io/repos/github/emccode/polly/badge.svg?branch=master)](https://coveralls.io/github/emccode/polly?branch=master) [ ![Download](http://api.bintray.com/packages/emccode/polly/stable/images/download.svg) ](https://dl.bintray.com/emccode/polly/stable/latest/)
 
 ![polly](docs/images/Polly the Parrot_Containers.png)
 


### PR DESCRIPTION
This should add bintray download support, coveralls support, hound (style enforcement), and codecov support. The go report is non-functional until we get rid of the go binary in the repo.