### PR TITLE
Added volume filter based on offer and scheduler assignment

### DIFF
--- a/api/admin/server/handlers.go
+++ b/api/admin/server/handlers.go
@@ -180,7 +180,7 @@ func (rtr *Router) postVolumesHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, ok := rtr.p.Services[strings.ToLower(m.ServiceName)]; !ok {
+	if _, ok := rtr.p.LsClient.Services[strings.ToLower(m.ServiceName)]; !ok {
 		http.Error(w, "ServiceName is not defined", http.StatusNotFound)
 		return
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -36,10 +36,7 @@ polly:
         localhost:
           address: tcp://localhost:7979
       services:
-        mock:
-          libstorage:
-            driver: mock
-        mock2:
+        mockService:
           libstorage:
             driver: mock
 `
@@ -95,7 +92,7 @@ func TestVolumesAll(t *testing.T) {
 	if err != nil {
 		t.FailNow()
 	}
-	assert.Len(t, vols, 6)
+	assert.Len(t, vols, 3)
 }
 
 func TestVolumes(t *testing.T) {
@@ -109,14 +106,14 @@ func TestVolumes(t *testing.T) {
 }
 
 func TestVolumeInspect(t *testing.T) {
-	vol, err := tpc.VolumeInspect("mock2-vol-000")
+	vol, err := tpc.VolumeInspect("mock-vol-000")
 
 	assert.NoError(t, err)
 	if err != nil {
 		t.FailNow()
 	}
-	assert.Equal(t, "mock2-vol-000", vol.VolumeID)
-	assert.Equal(t, "mock2", vol.ServiceName)
+	assert.Equal(t, "mock-vol-000", vol.VolumeID)
+	assert.Equal(t, "mockservice", vol.ServiceName)
 }
 
 func TestVolumeOffer(t *testing.T) {
@@ -127,7 +124,7 @@ func TestVolumeOffer(t *testing.T) {
 	}
 
 	assert.Equal(t, "mock-vol-001", vol.VolumeID)
-	assert.Equal(t, "mock", vol.ServiceName)
+	assert.Equal(t, "mockservice", vol.ServiceName)
 	assert.Contains(t, vol.Schedulers, "mesos")
 
 	vol, err = tpc.VolumeInspect("mock-vol-001")
@@ -148,7 +145,7 @@ func TestVolumeOfferMultiple(t *testing.T) {
 	}
 
 	assert.Equal(t, "mock-vol-001", vol.VolumeID)
-	assert.Equal(t, "mock", vol.ServiceName)
+	assert.Equal(t, "mockservice", vol.ServiceName)
 	assert.Contains(t, vol.Schedulers, "mesos")
 	assert.Contains(t, vol.Schedulers, "docker")
 
@@ -170,7 +167,7 @@ func TestVolumeOfferRevoke(t *testing.T) {
 	}
 
 	assert.Equal(t, "mock-vol-001", vol.VolumeID)
-	assert.Equal(t, "mock", vol.ServiceName)
+	assert.Equal(t, "mockservice", vol.ServiceName)
 	assert.Contains(t, vol.Schedulers, "mesos")
 	assert.Contains(t, vol.Schedulers, "docker")
 
@@ -181,7 +178,7 @@ func TestVolumeOfferRevoke(t *testing.T) {
 	}
 
 	assert.Equal(t, "mock-vol-001", vol.VolumeID)
-	assert.Equal(t, "mock", vol.ServiceName)
+	assert.Equal(t, "mockservice", vol.ServiceName)
 	assert.Len(t, vol.Schedulers, 0)
 
 	vol, err = tpc.VolumeInspect("mock-vol-001")
@@ -199,7 +196,7 @@ func TestVolumeLabel(t *testing.T) {
 		t.FailNow()
 	}
 	assert.Equal(t, "mock-vol-000", vol.VolumeID)
-	assert.Equal(t, "mock", vol.ServiceName)
+	assert.Equal(t, "mockservice", vol.ServiceName)
 
 	key1 := "key1"
 	value1 := "value1"
@@ -213,7 +210,7 @@ func TestVolumeLabel(t *testing.T) {
 	}
 
 	assert.Equal(t, "mock-vol-000", vol.VolumeID)
-	assert.Equal(t, "mock", vol.ServiceName)
+	assert.Equal(t, "mockservice", vol.ServiceName)
 	assert.Len(t, vol.Labels, 2)
 
 	vol, err = tpc.VolumeInspect("mock-vol-000")
@@ -284,7 +281,8 @@ func TestVolumeCreate(t *testing.T) {
 	schedulers := []string{"scheduler1", "scheduler2"}
 	labels := []string{fmt.Sprintf("%s=%s", key1, value1), fmt.Sprintf("%s=%s", key2, value2)}
 	fields := []string{fmt.Sprintf("%s=%s", key1, value1), fmt.Sprintf("%s=%s", key2, value2)}
-	service := "mock2"
+	service := "mockservice"
+	driver := "mock"
 	vol, err := tpc.VolumeCreate(service, name, vtype, size, IOPS, availabilityZone, schedulers, labels, fields)
 	assert.NoError(t, err)
 	if err != nil {
@@ -303,9 +301,9 @@ func TestVolumeCreate(t *testing.T) {
 	assert.Equal(t, name, vol.Volume.Name)
 	assert.Equal(t, size, vol.Volume.Size)
 	assert.Equal(t, vtype, vol.Volume.Type)
-	assert.Equal(t, fmt.Sprintf("%s-%s", service, "vol-004"), vol.VolumeID)
+	assert.Equal(t, fmt.Sprintf("%s-%s", driver, "vol-004"), vol.VolumeID)
 
-	vol, err = tpc.VolumeInspect(fmt.Sprintf("%s-%s", service, "vol-004"))
+	vol, err = tpc.VolumeInspect(fmt.Sprintf("%s-%s", driver, "vol-004"))
 	assert.NoError(t, err)
 	if err != nil {
 		t.FailNow()
@@ -323,7 +321,7 @@ func TestVolumeCreate(t *testing.T) {
 	assert.Equal(t, name, vol.Volume.Name)
 	assert.Equal(t, size, vol.Volume.Size)
 	assert.Equal(t, vtype, vol.Volume.Type)
-	assert.Equal(t, fmt.Sprintf("%s-%s", service, "vol-004"), vol.VolumeID)
+	assert.Equal(t, fmt.Sprintf("%s-%s", driver, "vol-004"), vol.VolumeID)
 
 }
 

--- a/core/store/store_test.go
+++ b/core/store/store_test.go
@@ -38,7 +38,8 @@ func newVolume(service, volumeID string) *types.Volume {
 	lsvol := &lstypes.Volume{
 		ID: volumeID,
 	}
-	return lsclient.NewVolume(lsvol, service)
+	vol, _ := lsclient.NewVolume(nil, lsvol, service)
+	return vol
 }
 
 func TestMain(m *testing.M) {

--- a/core/tests/lsclient_test.go
+++ b/core/tests/lsclient_test.go
@@ -78,7 +78,11 @@ func TestNewVolume(t *testing.T) {
 		Name: "mock1",
 		ID:   "vol-001",
 	}
-	vol := lsclient.NewVolume(avol, "mock")
+	vol, err := lsclient.NewVolume(p.LsClient, avol, "mock")
+	assert.NoError(t, err)
+	if err != nil {
+		t.FailNow()
+	}
 
 	assert.Equal(t, "mock1", vol.Name)
 	assert.Equal(t, "mock-vol-001", vol.VolumeID)

--- a/core/types/types.go
+++ b/core/types/types.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"github.com/akutz/gofig"
-	apitypes "github.com/emccode/libstorage/api/types"
 	lsclient "github.com/emccode/polly/core/libstorage/client"
 	store "github.com/emccode/polly/core/store"
 )
@@ -13,5 +12,4 @@ type Polly struct {
 	LsClient *lsclient.Client
 	Config   gofig.Config
 	LsConfig gofig.Config
-	Services apitypes.ServicesMap
 }

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,7 +5,7 @@ import:
     repo:    https://github.com/akutz/logrus
     vcs:     git
   - package: github.com/akutz/gofig
-    ref:     96b760df1cdbc843d5f633b7705f95c9090cb21e 
+    ref:     96b760df1cdbc843d5f633b7705f95c9090cb21e
     vcs:     git
   - package: github.com/akutz/gotil
     ref:     6fa2e80bd3ac40f15788cfc3d12ebba49a0add92
@@ -21,7 +21,7 @@ import:
     vcs:     git
   - package: github.com/stretchr/testify
   - package: github.com/emccode/libstorage
-    ref:     670d123dbd7159c7d44b55639a8d2ce4ab73d6fd 
+    ref:     v0.1.0-rc2 
     vcs:     git
     repo:    https://github.com/emccode/libstorage
   - package: github.com/docker/libkv

--- a/util/util.go
+++ b/util/util.go
@@ -252,3 +252,13 @@ func PrintVersion(out io.Writer) {
 	fmt.Fprintf(out, "Commit: %s\n", version.ShaLong)
 	fmt.Fprintf(out, "Formed: %s\n", version.EpochToRfc1123())
 }
+
+//ContainsString searches an array for a matching string
+func ContainsString(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
This commit introduces the capability to offer volumes to
specific schedulers. The scheduler names are synonymous with
service names here. The polly volume id was also updaed to
be based on driverName-volumeID.