### PR TITLE
modify uname flag from -p to -m

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ else
 		export GOARCH ?= amd64
 	endif
 	ifeq ($(origin GOARCH), undefined)
-		UNAME_P := $(shell uname -p)
+		UNAME_P := $(shell uname -m)
 		ifeq ($(UNAME_P),x86_64)
 			export GOARCH = amd64
 		endif


### PR DESCRIPTION
modifying Makefile to use "uname -m" instead of "uname -p". "uname -p" is not consistent between operating systems