### PR TITLE
Fix gopkg dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 go_import_path: github.com/emccode/polly
 
+before_install:
+  - git config --global 'url.https://gopkg.in/yaml.v1.insteadof' 'https://gopkg.in/yaml.v1/'
+  - git config --global 'url.https://gopkg.in/yaml.v2.insteadof' 'https://gopkg.in/yaml.v2/'
+  - git config --global 'url.https://gopkg.in/fsnotify.v1.insteadof' 'https://gopkg.in/fsnotify.v1/'
+  - git config --global 'url.https://github.com/.insteadof' 'git://github.com/'
+  - git config --global 'url.https://github.com/.insteadof' 'git@github.com:'
+
 language: go
 
 go:


### PR DESCRIPTION
Looks like some of the core golang package have changed requiring some additional steps in travis.