### PR TITLE
Update the polly dependencies to use recommended versions.

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -3,50 +3,47 @@ import:
   - package: github.com/Sirupsen/logrus
     ref:     feature/logrus-aware-types
     repo:    https://github.com/akutz/logrus
-    vcs:     git
-  - package: github.com/akutz/gofig
-    ref:     96b760df1cdbc843d5f633b7705f95c9090cb21e
-    vcs:     git
-  - package: github.com/akutz/gotil
-    ref:     6fa2e80bd3ac40f15788cfc3d12ebba49a0add92
-    vcs:     git
-  - package: github.com/akutz/goof
-    ref:     ea06624ca980bae80c1b615b8417723436d235ab
-    vcs:     git
-  - package: github.com/blang/semver
-    ref:     v3.0.1
-    vcs:     git
-  - package: github.com/cesanta/validate-json
-    ref:     2f16017c76fc2403d143e93cea1e1b9526a01148
-    vcs:     git
-  - package: github.com/stretchr/testify
+
   - package: github.com/emccode/libstorage
-    ref:     bb9b9477e65ae23c035dc78096e8870c306b7112
-    vcs:     git
-    repo:    https://github.com/clintonskitson/libstorage
+    version: v0.1.3
+
+  - package: github.com/akutz/gofig
+    version: v0.1.4
+  - package: github.com/akutz/gotil
+    version: v0.1.0
+  - package: github.com/akutz/goof
+    version: v0.1.0
+  - package: github.com/akutz/golf
+    ref:     v0.1.1
+
   - package: github.com/docker/libkv
-    vcs:     git
   - package: github.com/boltdb/bolt
-    vcs:     git
     ref:     dfb21201d9270c1082d5fb0f07f500311ff72f18
   - package: github.com/coreos/etcd/client
-    vcs:     git
     ref:     v2.3.3
   - package: github.com/samuel/go-zookeeper/zk
-    vcs:     git
     ref:     5250732bd2ed71d1e374212ebfc32760eca10c0a
+
+  - package: github.com/cesanta/validate-json
+    ref:     2f16017c76fc2403d143e93cea1e1b9526a01148
+  - package: github.com/stretchr/testify
   - package: github.com/spf13/pflag
     ref:     b084184666e02084b8ccb9b704bf0d79c466eb1d
     repo:    https://github.com/spf13/pflag
-    vcs:     git
   - package: github.com/spf13/cobra
     ref:     363816bb13ce1710460c2345017fd35593cbf5ed
     repo:    https://github.com/akutz/cobra
-    vcs:     git
-  - package: github.com/spf13/viper
-    ref:     support/rexray
-    repo:    https://github.com/akutz/viper.git
-    vcs:     git
-  - package: github.com/akutz/golf
-    ref:     v0.1.1
-    vcs:     git
+  - package: github.com/go-yaml/yaml
+    ref:     b4a9f8c4b84c6c4256d669c649837f1441e4b050
+    repo:    https://github.com/akutz/yaml.git
+  - package: gopkg.in/yaml.v1
+    ref:     b4a9f8c4b84c6c4256d669c649837f1441e4b050
+    repo:    https://github.com/akutz/yaml.git
+  - package: gopkg.in/yaml.v2
+    ref:     b4a9f8c4b84c6c4256d669c649837f1441e4b050
+    repo:    https://github.com/akutz/yaml.git
+  - package: google.golang.org/api/compute/v1
+    ref:     fd081149e482b10c55262756934088ffe3197ea3
+    repo:    https://github.com/google/google-api-go-client.git
+  - package: golang.org/x/net
+    repo:    https://github.com/golang/net


### PR DESCRIPTION
This is based on information in issue https://github.com/emccode/polly/issues/102 and some feedback provided by Andrew.