### PR TITLE
Fix the HTTP client from squashing the error message

### DIFF
--- a/api/admin/client/client_http.go
+++ b/api/admin/client/client_http.go
@@ -39,11 +39,14 @@ func (c *Client) httpDo(
 	c.logResponse(res)
 
 	if res.StatusCode > 299 {
-		httpErr, err := goof.DecodeHTTPError(res.Body)
+		errByte, err := ioutil.ReadAll(io.LimitReader(res.Body, 1048576))
+		var errStr string
 		if err != nil {
-			return res, goof.WithField("status", res.StatusCode, "http error")
+			errStr = "Failed to interpret HTTP Body for specific error message"
+		} else {
+			errStr = string(errByte)
 		}
-		return res, httpErr
+		return res, goof.WithField("status", res.StatusCode, errStr)
 	}
 
 	if req.Method != http.MethodHead && reply != nil {


### PR DESCRIPTION
This addresses issue https://github.com/emccode/polly/issues/82 and issue https://github.com/emccode/polly/issues/88

Tested in my virtualbox environment.
root@node0:/tmp# ./polly volume create --servicename=catbox --size=1
FATA[0000] mandatory Name missing or empty
              status=422