### PR TITLE
Update polly dependencies to the latest supported

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -3,50 +3,39 @@ import:
   - package: github.com/Sirupsen/logrus
     ref:     feature/logrus-aware-types
     repo:    https://github.com/akutz/logrus
-    vcs:     git
-  - package: github.com/akutz/gofig
-    ref:     96b760df1cdbc843d5f633b7705f95c9090cb21e
-    vcs:     git
-  - package: github.com/akutz/gotil
-    ref:     6fa2e80bd3ac40f15788cfc3d12ebba49a0add92
-    vcs:     git
-  - package: github.com/akutz/goof
-    ref:     ea06624ca980bae80c1b615b8417723436d235ab
-    vcs:     git
-  - package: github.com/blang/semver
-    ref:     v3.0.1
-    vcs:     git
-  - package: github.com/cesanta/validate-json
-    ref:     2f16017c76fc2403d143e93cea1e1b9526a01148
-    vcs:     git
-  - package: github.com/stretchr/testify
+
   - package: github.com/emccode/libstorage
-    ref:     bb9b9477e65ae23c035dc78096e8870c306b7112
+    ref:     ca8ecf16a73fff0be5918deffa42c8f2983b41c2
     vcs:     git
-    repo:    https://github.com/clintonskitson/libstorage
+    repo:    https://github.com/dvonthenen/libstorage
+
+  - package: github.com/akutz/gofig
+    version: v0.1.4
+  - package: github.com/akutz/gotil
+    version: v0.1.0
+  - package: github.com/akutz/goof
+    version: v0.1.0
+  - package: github.com/akutz/golf
+    ref:     v0.1.1
+
   - package: github.com/docker/libkv
-    vcs:     git
   - package: github.com/boltdb/bolt
-    vcs:     git
     ref:     dfb21201d9270c1082d5fb0f07f500311ff72f18
   - package: github.com/coreos/etcd/client
-    vcs:     git
     ref:     v2.3.3
   - package: github.com/samuel/go-zookeeper/zk
-    vcs:     git
     ref:     5250732bd2ed71d1e374212ebfc32760eca10c0a
+
+  - package: github.com/blang/semver
+    ref:     v3.0.1
+  - package: github.com/cesanta/validate-json
+  - package: github.com/stretchr/testify
   - package: github.com/spf13/pflag
     ref:     b084184666e02084b8ccb9b704bf0d79c466eb1d
     repo:    https://github.com/spf13/pflag
-    vcs:     git
   - package: github.com/spf13/cobra
     ref:     363816bb13ce1710460c2345017fd35593cbf5ed
     repo:    https://github.com/akutz/cobra
-    vcs:     git
   - package: github.com/spf13/viper
     ref:     support/rexray
     repo:    https://github.com/akutz/viper.git
-    vcs:     git
-  - package: github.com/akutz/golf
-    ref:     v0.1.1
-    vcs:     git


### PR DESCRIPTION
This addresses issue https://github.com/emccode/polly/issues/102

Please note that this commit changes the reference from github.com/clintonskitson/libstorage to github.com/dvonthenen/libstorage. This was done in order to update gofig to the latest as well as preserving the mock driver for CI testing.

Also, the commit looks messy only because it provides structure/organization to the file. What the file looks like in the end.

```
package: github.com/emccode/polly
import:
  - package: github.com/Sirupsen/logrus
    ref:     feature/logrus-aware-types
    repo:    https://github.com/akutz/logrus

  - package: github.com/emccode/libstorage
    ref:     ca8ecf16a73fff0be5918deffa42c8f2983b41c2
    vcs:     git
    repo:    https://github.com/dvonthenen/libstorage

  - package: github.com/akutz/gofig
    version: v0.1.4
  - package: github.com/akutz/gotil
    version: v0.1.0
  - package: github.com/akutz/goof
    version: v0.1.0
  - package: github.com/akutz/golf
    ref:     v0.1.1

  - package: github.com/docker/libkv
  - package: github.com/boltdb/bolt
    ref:     dfb21201d9270c1082d5fb0f07f500311ff72f18
  - package: github.com/coreos/etcd/client
    ref:     v2.3.3
  - package: github.com/samuel/go-zookeeper/zk
    ref:     5250732bd2ed71d1e374212ebfc32760eca10c0a

  - package: github.com/blang/semver
    ref:     v3.0.1
  - package: github.com/cesanta/validate-json
  - package: github.com/stretchr/testify
  - package: github.com/spf13/pflag
    ref:     b084184666e02084b8ccb9b704bf0d79c466eb1d
    repo:    https://github.com/spf13/pflag
  - package: github.com/spf13/cobra
    ref:     363816bb13ce1710460c2345017fd35593cbf5ed
    repo:    https://github.com/akutz/cobra
  - package: github.com/spf13/viper
    ref:     support/rexray
    repo:    https://github.com/akutz/viper.git
```