### PR TITLE
Update docs and code to flatten the config file

### DIFF
--- a/.docs/user-guide/configuration.md
+++ b/.docs/user-guide/configuration.md
@@ -16,18 +16,18 @@ polly:
     type: boltdb
     endpoints: /tmp/boltdb
     bucket: MyBoltDb_test
-  libstorage:
-    host: tcp://127.0.0.1:7981
-    embedded: false
-    server:
-      endpoints:
-        localhost:
-          address: tcp://:7981
-      services:
-        swarm_virtualbox:
-          libstorage:
-            storage:
-              driver: virtualbox
+libstorage:
+  host: tcp://127.0.0.1:7981
+  embedded: false
+  server:
+    endpoints:
+      localhost:
+        address: tcp://:7981
+    services:
+      swarm_virtualbox:
+        libstorage:
+          storage:
+            driver: virtualbox
 virtualbox:
   endpoint: http://10.0.2.2:18083
   tls: false
@@ -60,8 +60,8 @@ rexray:
       spec:     /etc/docker/plugins/virtualbox.spec
       libstorage:
         service: swarm_virtualbox
-  libstorage:
-    host: tcp://$POLLY_IP:7981
+libstorage:
+  host: tcp://$POLLY_IP:7981
 ```
 
 ## Firewall port openings

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -26,16 +26,16 @@ polly:
     type: boltdb
     endpoints: /tmp/boltdb
     bucket: MyBoltDb_test
-  libstorage:
-    host: tcp://localhost:7981
-    server:
-      endpoints:
-        localhost:
-          address: tcp://localhost:7981
-      services:
-        mockService:
-          libstorage:
-            driver: mock
+libstorage:
+  host: tcp://localhost:7981
+  server:
+    endpoints:
+      localhost:
+        address: tcp://localhost:7981
+    services:
+      mockService:
+        libstorage:
+          driver: mock
 `
 
 func TestMain(m *testing.M) {

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -15,17 +15,17 @@ polly:
     type: boltdb
     endpoints: /tmp/boltdb
     bucket: MyBoltDb_test
-  libstorage:
-    host: tcp://127.0.0.1:7981
-    embedded: false
-    server:
-      endpoints:
-        localhost:
-          address: tcp://:7981
-      services:
-        mock:
-          libstorage:
-            driver: mock
+libstorage:
+  host: tcp://127.0.0.1:7981
+  embedded: false
+  server:
+    endpoints:
+      localhost:
+        address: tcp://:7981
+    services:
+      mock:
+        libstorage:
+          driver: mock
 `
 
 // New returns a new configuration object

--- a/core/tests/lsclient_test.go
+++ b/core/tests/lsclient_test.go
@@ -10,14 +10,16 @@ import (
 	gofig "github.com/akutz/gofig"
 
 	"bytes"
+
 	"github.com/akutz/goof"
 	apitypes "github.com/emccode/libstorage/api/types"
+
+	"strings"
 
 	"github.com/emccode/polly/core"
 	lsclient "github.com/emccode/polly/core/libstorage/client"
 	"github.com/emccode/polly/core/types"
 	"github.com/stretchr/testify/assert"
-	"strings"
 )
 
 // This testing package is against the libStorage client
@@ -31,21 +33,21 @@ polly:
     type: boltdb
     endpoints: /tmp/boltdb
     bucket: MyBoltDb_test
-  libstorage:
-    host: tcp://localhost:7981
-    client:
-      requestPath: client
-    server:
-      endpoints:
-        localhost:
-          address: tcp://localhost:7981
-      services:
-        vfs:
-          libstorage:
-            driver: vfs
-        vfs2:
-          libstorage:
-            driver: vfs
+libstorage:
+  host: tcp://localhost:7981
+  client:
+    requestPath: client
+  server:
+    endpoints:
+      localhost:
+        address: tcp://localhost:7981
+    services:
+      vfs:
+        libstorage:
+          driver: vfs
+      vfs2:
+        libstorage:
+          driver: vfs
 `
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
The libstorage sections in the docs and code (there are some configuration in the code to drive things like testing) have been modified such that they are at the same level as polly. This addresses issue https://github.com/emccode/polly/issues/106.

Previously the docs/code looked like:
```
 polly:
   host: tcp://127.0.0.1:7978
   store:
     type: boltdb
     endpoints: /tmp/boltdb
     bucket: MyBoltDb_test
   libstorage:
     host: tcp://localhost:7981
     server:
       endpoints:
...
```

Now the docs/code look like:
```
polly:
  host: tcp://localhost:7978
  store:
    type: boltdb
    endpoints: /tmp/boltdb
    bucket: MyBoltDb_test
libstorage:
  host: tcp://localhost:7981
  client:
    requestPath: client
  server:
    endpoints:
...
```

