### PR TITLE
Add more panic logging

### DIFF
--- a/polly/cli/cli.go
+++ b/polly/cli/cli.go
@@ -213,7 +213,7 @@ func (c *CLI) Execute() {
 		case error:
 			log.Panic(r)
 		default:
-			log.Debugf("exiting with default error code 1, r=%v", r)
+			log.Debugf("exiting1 with default error code 1, r=%v", r)
 			os.Exit(1)
 		}
 	}()
@@ -228,8 +228,10 @@ func (c *CLI) execute() {
 			case helpFlagPanic, subCommandPanic:
 			// Do nothing
 			case printedErrorPanic:
+				log.Panic(r)
 				os.Exit(1)
 			default:
+				log.Debugf("exiting2 with default error code 1, r=%v", r)
 				panic(r)
 			}
 		}


### PR DESCRIPTION
Added more logging to section of code where recover() is being called. There was one particular call missing logging. Part of the issue is triggering an event that would cause this to log. Additionally if an application is going awry, you can't expect the logging functionality within the application to continue to function normally.